### PR TITLE
CSRF脆弱性に対策し、削除時にもワンタイムトークンで安全に

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -71,18 +71,25 @@ function handleDelete(req, res) {
     case 'POST':
       req.on('data', (data) => {
         const decoded = decodeURIComponent(data);
-        const id = decoded.split('id=')[1];
-        Post.findById(id).then((post) => {
-          if (req.user === post.postedBy || req.user === 'admin') {
-            post.destroy();
-            console.info(
-              `削除されました: user: ${req.user}, ` +
-              `remoteAddress: ${req.connection.remoteAddress}, ` +
-              `userAgent: ${req.headers['user-agent']} `
+        const dataArray = decoded.split('&');
+        const id = dataArray[0] ? dataArray[0].split('id=')[1] : '';
+        const requestedOneTimeToken = dataArray[1] ? dataArray[1].split('oneTimeToken=')[1] : '';
+        if (oneTimeTokenMap.get(req.user) === requestedOneTimeToken) {
+          Post.findById(id).then((post) => {
+            if (req.user === post.postedBy || req.user === 'admin') {
+              post.destroy();
+              console.info(
+                `削除されました: user: ${req.user}, ` +
+                `remoteAddress: ${req.connection.remoteAddress}, ` +
+                `userAgent: ${req.headers['user-agent']} `
               );
-          }
-          handleRedirectPosts(req, res);
-        });
+              oneTimeTokenMap.delete(req.user);
+            }
+            handleRedirectPosts(req, res);
+          });
+        } else {
+          util.handleBadRequest(req, res);
+        }
       });
       break;
     default:
@@ -115,9 +122,9 @@ function isValidTrackingId(trackingId, userName) {
   if (!trackingId) {
     return false;
   }
-  const spilited = trackingId.split('_');
-  const originalId = spilited[0];
-  const requestedHash = spilited[1];
+  const splited = trackingId.split('_');
+  const originalId = splited[0];
+  const requestedHash = splited[1];
   return createValidHash(originalId, userName) === requestedHash;
 }
 

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -44,6 +44,7 @@ html(lang="jp")
           if isDeletable
             form(method="post", action="/posts?delete=1")
               input(type="hidden", name="id", value="#{post.id}")
+              input(type="hidden", name="oneTimeToken", value="#{oneTimeToken}")
               button(type="submit", class="btn btn-danger pull-right") 削除
               div(class="row")
     script(src="https://code.jquery.com/jquery-2.2.0.min.js")


### PR DESCRIPTION
練習用なので、マージは不要です。（以下、長文です。とても難しかったもので・・・）

ワンタイムトークンの実装が、物凄く難しかったです。（泣き）
概念は、なんとなく理解できても、それをコードで表現する作業が大変でした。
（新しいフォルダに、git clone して、手打ちで書いたり消したりで、エラーメッセージへの修正が一筋縄に行きませんでした。**_復習にかかった時間＝３時間３０分_**）

**_練習問題は_**、投稿のときと同じ感じにすれば良さそうと思い、答えやヒント無しで挑戦しました。
（この軽い気持ちが命取りでした。コードのどこを、どういじれば良いのか、相当な回数をエラーメッセージとにらめっこをしながら、試行錯誤しました。）
動作確認は出来たのですが、ないものを無いと確認するのが、「悪魔の証明」みたいで、少し不安でした。答えと見比べて、ミスがなかったので、OKだと思います。
（流石に、これだけの時間を勉強すると、頭がぼんやりとしてきました。）

ヘロクへの実装は、そんなに難しく無さそうだったので、明日の金曜日の天皇誕生日に、実装する予定です。

ヘロクへの実装の授業時に、**_吉村先生の作られた、コメントビュー_**ワが物凄く生き生きとしていました。
もし、コメントビューワが無かったら、ヘロクのURLを、どうやって連絡しあっていたのだろうかと思うと、少し背筋がひんやりしました。吉村先生、ありがとうございます。（ブックマークレットのほうで、FireFox_50.1.0 において正常に動作しましたことを、報告いたします。）

来週から、ワードプレスかなにか、みたいな良くわからない感じですが、今回の脆弱性対策が、楽をして出来そうなので、楽しみにしております。ほんとうに、いつもありがとうございます。 m(__)m